### PR TITLE
Add error handling to color to prevent fb-chat-api error

### DIFF
--- a/modules/color.js
+++ b/modules/color.js
@@ -46,7 +46,9 @@ function trigger(color, api, message) {
     color = handleColor(color.toLowerCase(), threadID, api);
   }
   if (color && color != INVALID) {
-    api.changeThreadColor(color, threadID);
+    api.changeThreadColor(color, threadID, function(err) {
+      if (err) return console.error(err);
+    });
   }
 }
 


### PR DESCRIPTION
changeThreadColor needs an error handler or facebook-chat-api complains
